### PR TITLE
hotfix: solve docs build error

### DIFF
--- a/docs/src/08_concepts.adoc
+++ b/docs/src/08_concepts.adoc
@@ -3,11 +3,6 @@ ifndef::imagesdir[:imagesdir: ../images]
 [[section-concepts]]
 == Cross-cutting Concepts
 
-
-[role="arc42help"]
-****
-
-
 .Domain Model
 These diagram is just a sketch, it should be replaced by a more accurate version upon discussion.
 


### PR DESCRIPTION
An build error has been solved, in which not the entire documentation was built.