### PR TITLE
Added tests for the Authentication endpoints

### DIFF
--- a/api/pom.xml
+++ b/api/pom.xml
@@ -44,6 +44,11 @@
 			<scope>runtime</scope>
 		</dependency>
 		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-validation</artifactId>
+			<version>3.2.2</version>
+		</dependency>
+		<dependency>
 			<groupId>org.projectlombok</groupId>
 			<artifactId>lombok</artifactId>
 			<optional>true</optional>

--- a/api/src/main/java/lab/en2b/quizapi/auth/AuthService.java
+++ b/api/src/main/java/lab/en2b/quizapi/auth/AuthService.java
@@ -21,7 +21,6 @@ import java.util.Set;
 @Service
 @RequiredArgsConstructor
 public class AuthService {
-    private final JwtUtils jwtUtils;
     private final AuthenticationManager authenticationManager;
     private final UserService userService;
     /**
@@ -37,7 +36,7 @@ public class AuthService {
         UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
 
         return ResponseEntity.ok(new JwtResponseDto(
-                jwtUtils.generateJwtTokenUserPassword(authentication),
+                JwtUtils.generateJwtTokenUserPassword(authentication),
                 userService.assignNewRefreshToken(userDetails.getId()),
                 userDetails.getId(),
                 userDetails.getUsername(),
@@ -65,6 +64,6 @@ public class AuthService {
     public ResponseEntity<?> refreshToken(RefreshTokenDto refreshTokenRequest) {
         User user = userService.findByRefreshToken(refreshTokenRequest.getRefreshToken()).orElseThrow(() -> new TokenRefreshException(
                 "Refresh token is not in database!"));
-        return ResponseEntity.ok(new RefreshTokenResponseDto(jwtUtils.generateTokenFromEmail(user.getEmail()), user.obtainRefreshIfValid()));
+        return ResponseEntity.ok(new RefreshTokenResponseDto(JwtUtils.generateTokenFromEmail(user.getEmail()), user.obtainRefreshIfValid()));
     }
 }

--- a/api/src/main/java/lab/en2b/quizapi/auth/AuthService.java
+++ b/api/src/main/java/lab/en2b/quizapi/auth/AuthService.java
@@ -23,6 +23,7 @@ import java.util.Set;
 public class AuthService {
     private final AuthenticationManager authenticationManager;
     private final UserService userService;
+    private final JwtUtils jwtUtils;
     /**
      * Creates a session for a user. Throws an 401 unauthorized exception otherwise
      * @param loginRequest the request containing the login info
@@ -36,7 +37,7 @@ public class AuthService {
         UserDetailsImpl userDetails = (UserDetailsImpl) authentication.getPrincipal();
 
         return ResponseEntity.ok(new JwtResponseDto(
-                JwtUtils.generateJwtTokenUserPassword(authentication),
+                jwtUtils.generateJwtTokenUserPassword(authentication),
                 userService.assignNewRefreshToken(userDetails.getId()),
                 userDetails.getId(),
                 userDetails.getUsername(),
@@ -64,6 +65,6 @@ public class AuthService {
     public ResponseEntity<?> refreshToken(RefreshTokenDto refreshTokenRequest) {
         User user = userService.findByRefreshToken(refreshTokenRequest.getRefreshToken()).orElseThrow(() -> new TokenRefreshException(
                 "Refresh token is not in database!"));
-        return ResponseEntity.ok(new RefreshTokenResponseDto(JwtUtils.generateTokenFromEmail(user.getEmail()), user.obtainRefreshIfValid()));
+        return ResponseEntity.ok(new RefreshTokenResponseDto(jwtUtils.generateTokenFromEmail(user.getEmail()), user.obtainRefreshIfValid()));
     }
 }

--- a/api/src/main/java/lab/en2b/quizapi/auth/dtos/JwtResponseDto.java
+++ b/api/src/main/java/lab/en2b/quizapi/auth/dtos/JwtResponseDto.java
@@ -1,15 +1,15 @@
 package lab.en2b.quizapi.auth.dtos;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 import java.util.List;
 
 @AllArgsConstructor
 @NoArgsConstructor
 @Getter
+@Builder
+@EqualsAndHashCode
 public class JwtResponseDto {
     private String token;
     @JsonProperty("refresh_token")

--- a/api/src/main/java/lab/en2b/quizapi/auth/dtos/LoginDto.java
+++ b/api/src/main/java/lab/en2b/quizapi/auth/dtos/LoginDto.java
@@ -1,5 +1,7 @@
 package lab.en2b.quizapi.auth.dtos;
 
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,7 +12,10 @@ import lombok.NonNull;
 @Data
 public class LoginDto {
     @NonNull
+    @NotBlank
+    @Email
     private String email;
     @NonNull
+    @NotBlank
     private String password;
 }

--- a/api/src/main/java/lab/en2b/quizapi/auth/dtos/RefreshTokenDto.java
+++ b/api/src/main/java/lab/en2b/quizapi/auth/dtos/RefreshTokenDto.java
@@ -1,6 +1,7 @@
 package lab.en2b.quizapi.auth.dtos;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
+import jakarta.validation.constraints.NotEmpty;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -10,7 +11,8 @@ import lombok.NonNull;
 @NoArgsConstructor
 @Data
 public class RefreshTokenDto {
-    @NonNull
     @JsonProperty("refresh_token")
+    @NonNull
+    @NotEmpty
     private String refreshToken;
 }

--- a/api/src/main/java/lab/en2b/quizapi/auth/dtos/RefreshTokenResponseDto.java
+++ b/api/src/main/java/lab/en2b/quizapi/auth/dtos/RefreshTokenResponseDto.java
@@ -1,15 +1,13 @@
 package lab.en2b.quizapi.auth.dtos;
 
 import com.fasterxml.jackson.annotation.JsonProperty;
-import lombok.AllArgsConstructor;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
-import lombok.Setter;
+import lombok.*;
 
 @Getter
 @Setter
 @AllArgsConstructor
 @NoArgsConstructor
+@EqualsAndHashCode
 public class RefreshTokenResponseDto {
 
     private String token;

--- a/api/src/main/java/lab/en2b/quizapi/auth/dtos/RegisterDto.java
+++ b/api/src/main/java/lab/en2b/quizapi/auth/dtos/RegisterDto.java
@@ -1,5 +1,6 @@
 package lab.en2b.quizapi.auth.dtos;
 
+import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -9,10 +10,13 @@ import lombok.NonNull;
 @NoArgsConstructor
 @Data
 public class RegisterDto {
+    @NotBlank
     @NonNull
     private String email;
     @NonNull
+    @NotBlank
     private String username;
     @NonNull
+    @NotBlank
     private String password;
 }

--- a/api/src/main/java/lab/en2b/quizapi/auth/dtos/RegisterDto.java
+++ b/api/src/main/java/lab/en2b/quizapi/auth/dtos/RegisterDto.java
@@ -1,5 +1,6 @@
 package lab.en2b.quizapi.auth.dtos;
 
+import jakarta.validation.constraints.Email;
 import jakarta.validation.constraints.NotBlank;
 import lombok.AllArgsConstructor;
 import lombok.Data;
@@ -12,6 +13,7 @@ import lombok.NonNull;
 public class RegisterDto {
     @NotBlank
     @NonNull
+    @Email
     private String email;
     @NonNull
     @NotBlank

--- a/api/src/main/java/lab/en2b/quizapi/auth/jwt/JwtUtils.java
+++ b/api/src/main/java/lab/en2b/quizapi/auth/jwt/JwtUtils.java
@@ -20,11 +20,11 @@ public class JwtUtils {
 
     //MUST BE SET AS ENVIRONMENT VARIABLE
     @Value("${JWT_SECRET}")
-    private static String JWT_SECRET;
+    private String JWT_SECRET;
     @Value("${JWT_EXPIRATION_MS}")
-    private static Long JWT_EXPIRATION_MS;
+    private Long JWT_EXPIRATION_MS;
 
-    public static String generateJwtTokenUserPassword(Authentication authentication) {
+    public String generateJwtTokenUserPassword(Authentication authentication) {
         UserDetailsImpl userPrincipal = (UserDetailsImpl) authentication.getPrincipal();
 
         return Jwts.builder()
@@ -34,7 +34,7 @@ public class JwtUtils {
                 .signWith(getSignInKey())
                 .compact();
     }
-    public static boolean validateJwtToken(String authToken) {
+    public boolean validateJwtToken(String authToken) {
         try {
             Jwts.parser().verifyWith(getSignInKey()).build().parseSignedClaims(authToken);
             return true;
@@ -51,18 +51,18 @@ public class JwtUtils {
         }
         return false;
     }
-    public static <T> T extractClaim(String token, Function<Claims,T> claimsResolver){
+    public <T> T extractClaim(String token, Function<Claims,T> claimsResolver){
         final Claims claims = extractAllClaims(token);
         return claimsResolver.apply(claims);
     }
-    public static String getSubjectFromJwtToken(String token) {
+    public String getSubjectFromJwtToken(String token) {
         if(validateJwtToken(token)){
             return extractClaim(token, Claims::getSubject);
         }else{
             throw new IllegalArgumentException();
         }
     }
-    public static String generateTokenFromEmail(String email) {
+    public String generateTokenFromEmail(String email) {
         return Jwts.builder()
                 .subject(email)
                 .issuedAt(new Date())
@@ -70,11 +70,11 @@ public class JwtUtils {
                 .signWith(getSignInKey())
                 .compact();
     }
-    private static SecretKey getSignInKey(){
+    private SecretKey getSignInKey(){
         byte[] keyBytes = Decoders.BASE64.decode(JWT_SECRET);
         return Keys.hmacShaKeyFor(keyBytes);
     }
-    private static Claims extractAllClaims(String token){
+    private Claims extractAllClaims(String token){
         return Jwts.parser()
                 .verifyWith(getSignInKey())
                 .build()

--- a/api/src/main/java/lab/en2b/quizapi/auth/jwt/JwtUtils.java
+++ b/api/src/main/java/lab/en2b/quizapi/auth/jwt/JwtUtils.java
@@ -20,11 +20,11 @@ public class JwtUtils {
 
     //MUST BE SET AS ENVIRONMENT VARIABLE
     @Value("${JWT_SECRET}")
-    private String JWT_SECRET;
+    private static String JWT_SECRET;
     @Value("${JWT_EXPIRATION_MS}")
-    private Long JWT_EXPIRATION_MS;
+    private static Long JWT_EXPIRATION_MS;
 
-    public String generateJwtTokenUserPassword(Authentication authentication) {
+    public static String generateJwtTokenUserPassword(Authentication authentication) {
         UserDetailsImpl userPrincipal = (UserDetailsImpl) authentication.getPrincipal();
 
         return Jwts.builder()
@@ -34,7 +34,7 @@ public class JwtUtils {
                 .signWith(getSignInKey())
                 .compact();
     }
-    public boolean validateJwtToken(String authToken) {
+    public static boolean validateJwtToken(String authToken) {
         try {
             Jwts.parser().verifyWith(getSignInKey()).build().parseSignedClaims(authToken);
             return true;
@@ -51,18 +51,18 @@ public class JwtUtils {
         }
         return false;
     }
-    public <T> T extractClaim(String token, Function<Claims,T> claimsResolver){
+    public static <T> T extractClaim(String token, Function<Claims,T> claimsResolver){
         final Claims claims = extractAllClaims(token);
         return claimsResolver.apply(claims);
     }
-    public String getSubjectFromJwtToken(String token) {
+    public static String getSubjectFromJwtToken(String token) {
         if(validateJwtToken(token)){
             return extractClaim(token, Claims::getSubject);
         }else{
             throw new IllegalArgumentException();
         }
     }
-    public String generateTokenFromEmail(String email) {
+    public static String generateTokenFromEmail(String email) {
         return Jwts.builder()
                 .subject(email)
                 .issuedAt(new Date())
@@ -70,11 +70,11 @@ public class JwtUtils {
                 .signWith(getSignInKey())
                 .compact();
     }
-    private SecretKey getSignInKey(){
+    private static SecretKey getSignInKey(){
         byte[] keyBytes = Decoders.BASE64.decode(JWT_SECRET);
         return Keys.hmacShaKeyFor(keyBytes);
     }
-    private Claims extractAllClaims(String token){
+    private static Claims extractAllClaims(String token){
         return Jwts.parser()
                 .verifyWith(getSignInKey())
                 .build()

--- a/api/src/main/java/lab/en2b/quizapi/commons/user/UserService.java
+++ b/api/src/main/java/lab/en2b/quizapi/commons/user/UserService.java
@@ -23,7 +23,7 @@ public class UserService implements UserDetailsService {
     private final UserRepository userRepository;
     private final RoleRepository roleRepository;
     @Value("${REFRESH_TOKEN_DURATION_MS}")
-    private Long REFRESH_TOKEN_DURATION_MS;
+    private long REFRESH_TOKEN_DURATION_MS;
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
         return UserDetailsImpl.build(userRepository.findByEmail(email).orElseThrow());

--- a/api/src/main/java/lab/en2b/quizapi/commons/utils/TestUtils.java
+++ b/api/src/main/java/lab/en2b/quizapi/commons/utils/TestUtils.java
@@ -1,0 +1,13 @@
+package lab.en2b.quizapi.commons.utils;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+
+public class TestUtils {
+    public static String asJsonString(final Object obj) {
+        try {
+            return new ObjectMapper().writeValueAsString(obj);
+        } catch (Exception e) {
+            throw new RuntimeException(e);
+        }
+    }
+}

--- a/api/src/test/java/lab/en2b/quizapi/auth/AuthControllerTest.java
+++ b/api/src/test/java/lab/en2b/quizapi/auth/AuthControllerTest.java
@@ -1,6 +1,7 @@
 package lab.en2b.quizapi.auth;
 
 import lab.en2b.quizapi.auth.config.SecurityConfig;
+import lab.en2b.quizapi.auth.dtos.LoginDto;
 import lab.en2b.quizapi.auth.dtos.RegisterDto;
 import lab.en2b.quizapi.auth.jwt.JwtUtils;
 import lab.en2b.quizapi.commons.user.UserService;
@@ -49,8 +50,45 @@ public class AuthControllerTest {
                 status().isBadRequest());
     }
 
+    @Test
+    void registerEmptyUsernameShouldReturn400() throws Exception {
+        testRegister(asJsonString( new RegisterDto("test@email.com","","testing")),
+                status().isBadRequest());
+    }
+
+    @Test
+    void registerEmptyPasswordShouldReturn400() throws Exception {
+        testRegister(asJsonString( new RegisterDto("test@email.com","test","")),
+                status().isBadRequest());
+    }
+
+    @Test
+    void loginUserShouldReturn200() throws Exception {
+        when(authService.login(any())).thenReturn(ResponseEntity.ok().build());
+        testLogin(asJsonString( new LoginDto("test@email.com","password"))
+                ,status().isOk());
+    }
+
+    @Test
+    void loginEmptyBodyShouldReturn400() throws Exception {
+        testLogin("{}",status().isBadRequest());
+    }
+    @Test
+    void loginEmptyEmailShouldReturn400() throws Exception {
+        testLogin(asJsonString( new LoginDto("","password")),
+                status().isBadRequest());
+    }
+
     private void testRegister(String content, ResultMatcher code) throws Exception {
         mockMvc.perform(post("/auth/register")
+                        .content(content)
+                        .contentType("application/json")
+                        .with(csrf()))
+                .andExpect(code);
+    }
+
+    private void testLogin(String content, ResultMatcher code) throws Exception {
+        mockMvc.perform(post("/auth/login")
                         .content(content)
                         .contentType("application/json")
                         .with(csrf()))

--- a/api/src/test/java/lab/en2b/quizapi/auth/AuthControllerTest.java
+++ b/api/src/test/java/lab/en2b/quizapi/auth/AuthControllerTest.java
@@ -1,0 +1,59 @@
+package lab.en2b.quizapi.auth;
+
+import lab.en2b.quizapi.auth.config.SecurityConfig;
+import lab.en2b.quizapi.auth.dtos.RegisterDto;
+import lab.en2b.quizapi.auth.jwt.JwtUtils;
+import lab.en2b.quizapi.commons.user.UserService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.ResultMatcher;
+
+import static lab.en2b.quizapi.commons.utils.TestUtils.asJsonString;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(AuthController.class)
+@AutoConfigureMockMvc
+@Import(SecurityConfig.class)
+public class AuthControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+    @MockBean
+    AuthService authService;
+    @MockBean
+    JwtUtils jwtUtils;
+    @MockBean
+    UserService userService;
+    @Test
+    void registerUserShouldReturn200() throws Exception {
+        when(authService.register(any())).thenReturn(ResponseEntity.ok().build());
+        testRegister(asJsonString( new RegisterDto("test@email.com","test","testing"))
+                ,status().isOk());
+    }
+    @Test
+    void registerEmptyBodyShouldReturn400() throws Exception {
+        testRegister("{}",status().isBadRequest());
+    }
+    @Test
+    void registerEmptyEmailShouldReturn400() throws Exception {
+        testRegister(asJsonString( new RegisterDto("","test","testing")),
+                status().isBadRequest());
+    }
+
+    private void testRegister(String content, ResultMatcher code) throws Exception {
+        mockMvc.perform(post("/auth/register")
+                        .content(content)
+                        .contentType("application/json")
+                        .with(csrf()))
+                .andExpect(code);
+    }
+}

--- a/api/src/test/java/lab/en2b/quizapi/auth/AuthControllerTest.java
+++ b/api/src/test/java/lab/en2b/quizapi/auth/AuthControllerTest.java
@@ -2,6 +2,7 @@ package lab.en2b.quizapi.auth;
 
 import lab.en2b.quizapi.auth.config.SecurityConfig;
 import lab.en2b.quizapi.auth.dtos.LoginDto;
+import lab.en2b.quizapi.auth.dtos.RefreshTokenDto;
 import lab.en2b.quizapi.auth.dtos.RegisterDto;
 import lab.en2b.quizapi.auth.jwt.JwtUtils;
 import lab.en2b.quizapi.commons.user.UserService;
@@ -91,6 +92,25 @@ public class AuthControllerTest {
                 status().isBadRequest());
     }
 
+    @Test
+    void refreshTokenShouldReturn200() throws Exception {
+        when(authService.refreshToken(any())).thenReturn(ResponseEntity.ok().build());
+        testRefreshToken(asJsonString( new RefreshTokenDto("58ca95e9-c4ef-45fd-93cf-55c040aaff9c"))
+                ,status().isOk());
+    }
+
+    @Test
+    void refreshTokenEmptyBodyShouldReturn400() throws Exception {
+        when(authService.refreshToken(any())).thenReturn(ResponseEntity.ok().build());
+        testRefreshToken("{}",status().isBadRequest());
+    }
+
+    @Test
+    void refreshTokenEmptyTokenShouldReturn400() throws Exception {
+        when(authService.refreshToken(any())).thenReturn(ResponseEntity.ok().build());
+        testRefreshToken(asJsonString( new RefreshTokenDto("")), status().isBadRequest());
+    }
+
     private void testRegister(String content, ResultMatcher code) throws Exception {
         mockMvc.perform(post("/auth/register")
                         .content(content)
@@ -101,6 +121,14 @@ public class AuthControllerTest {
 
     private void testLogin(String content, ResultMatcher code) throws Exception {
         mockMvc.perform(post("/auth/login")
+                        .content(content)
+                        .contentType("application/json")
+                        .with(csrf()))
+                .andExpect(code);
+    }
+
+    private void testRefreshToken(String content, ResultMatcher code) throws Exception {
+        mockMvc.perform(post("/auth/refresh-token")
                         .content(content)
                         .contentType("application/json")
                         .with(csrf()))

--- a/api/src/test/java/lab/en2b/quizapi/auth/AuthControllerTest.java
+++ b/api/src/test/java/lab/en2b/quizapi/auth/AuthControllerTest.java
@@ -51,6 +51,12 @@ public class AuthControllerTest {
     }
 
     @Test
+    void registerInvalidEmailShouldReturn400() throws Exception {
+        testRegister(asJsonString( new RegisterDto("iAmAnInvalidEmail","test","testing")),
+                status().isBadRequest());
+    }
+
+    @Test
     void registerEmptyUsernameShouldReturn400() throws Exception {
         testRegister(asJsonString( new RegisterDto("test@email.com","","testing")),
                 status().isBadRequest());
@@ -76,6 +82,12 @@ public class AuthControllerTest {
     @Test
     void loginEmptyEmailShouldReturn400() throws Exception {
         testLogin(asJsonString( new LoginDto("","password")),
+                status().isBadRequest());
+    }
+
+    @Test
+    void loginInvalidEmailShouldReturn400() throws Exception {
+        testLogin(asJsonString( new LoginDto("iAmAnInvalidEmail","password")),
                 status().isBadRequest());
     }
 

--- a/api/src/test/java/lab/en2b/quizapi/auth/AuthServiceTest.java
+++ b/api/src/test/java/lab/en2b/quizapi/auth/AuthServiceTest.java
@@ -1,0 +1,81 @@
+package lab.en2b.quizapi.auth;
+
+import lab.en2b.quizapi.auth.config.UserDetailsImpl;
+import lab.en2b.quizapi.auth.dtos.JwtResponseDto;
+import lab.en2b.quizapi.auth.dtos.LoginDto;
+import lab.en2b.quizapi.auth.jwt.JwtUtils;
+import lab.en2b.quizapi.commons.user.User;
+import lab.en2b.quizapi.commons.user.UserRepository;
+import lab.en2b.quizapi.commons.user.UserService;
+import lab.en2b.quizapi.commons.user.role.Role;
+import lab.en2b.quizapi.commons.user.role.RoleRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.core.Authentication;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({MockitoExtension.class, SpringExtension.class})
+public class AuthServiceTest {
+    @InjectMocks
+    AuthService authService;
+    UserService userService;
+    @Mock
+    UserRepository userRepository;
+    @Mock
+    RoleRepository roleRepository;
+    @Mock
+    AuthenticationManager authenticationManager;
+    @Mock
+    JwtUtils jwtUtils;
+    User defaultUser;
+    @BeforeEach
+    void setUp() {
+        this.userService = new UserService(userRepository,roleRepository);
+        this.authService = new AuthService(authenticationManager,userService,jwtUtils);
+        this.defaultUser = User.builder()
+                .id(1L)
+                .email("test@email.com")
+                .username("test")
+                .roles(Set.of(new Role("user")))
+                .password("password")
+                .build();
+    }
+    @Test
+    void testLogin(){
+        Authentication authentication = mock(Authentication.class);
+
+        when(authenticationManager.authenticate(any())).thenReturn(authentication);
+        when(authentication.getPrincipal()).thenReturn(UserDetailsImpl.build(defaultUser));
+        when(jwtUtils.generateJwtTokenUserPassword(authentication)).thenReturn("jwtToken");
+        when(userRepository.findById(any())).thenReturn(Optional.of(defaultUser));
+
+        ResponseEntity<JwtResponseDto> actual = authService.login(new LoginDto("test","password"));
+
+        assertEquals(ResponseEntity.of(Optional.of(
+                JwtResponseDto.builder()
+                        .userId(1L)
+                        .username(defaultUser.getUsername())
+                        .email(defaultUser.getEmail())
+                        .refreshToken(defaultUser.getRefreshToken())
+                        .token("jwtToken")
+                        .roles(List.of("user"))
+                        .build()))
+                ,actual);
+
+    }
+}


### PR DESCRIPTION
I have added tests for the SpringBoot API testing the following endpoints:

- **/register**
- **/login**
- **/refresh-token**

The tests developed from now on shall follow the same format as the ones provided here.
They shall also be added to a test suit in Github actions as described in #61 