### PR TITLE
fix: invalid credentials now returns descriptive error instead of generic one

### DIFF
--- a/api/src/main/java/lab/en2b/quizapi/commons/exceptions/CustomControllerAdvice.java
+++ b/api/src/main/java/lab/en2b/quizapi/commons/exceptions/CustomControllerAdvice.java
@@ -18,6 +18,11 @@ import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExcep
 @Log4j2
 @Order(Ordered.HIGHEST_PRECEDENCE)
 public class CustomControllerAdvice extends ResponseEntityExceptionHandler {
+    @ExceptionHandler(InvalidAuthenticationException.class)
+    public ResponseEntity<String> handleInvalidAuthenticationException(InvalidAuthenticationException exception){
+        log.error(exception.getMessage(),exception);
+        return new ResponseEntity<>(exception.getMessage(),HttpStatus.UNAUTHORIZED);
+    }
     @ExceptionHandler(NoSuchElementException.class)
     public ResponseEntity<String> handleNoSuchElementException(NoSuchElementException exception){
         log.error(exception.getMessage(),exception);
@@ -50,7 +55,7 @@ public class CustomControllerAdvice extends ResponseEntityExceptionHandler {
     @ExceptionHandler(InternalAuthenticationServiceException.class)
     public ResponseEntity<String> handleInternalAuthenticationServiceException(InternalAuthenticationServiceException exception) {
         log.error(exception.getMessage(),exception);
-        return new ResponseEntity<>(exception.getMessage(),HttpStatus.FORBIDDEN);
+        return new ResponseEntity<>(exception.getMessage(),HttpStatus.UNAUTHORIZED);
     }
     @ExceptionHandler(Exception.class)
     public ResponseEntity<String> handleException(Exception exception){

--- a/api/src/main/java/lab/en2b/quizapi/commons/exceptions/InvalidAuthenticationException.java
+++ b/api/src/main/java/lab/en2b/quizapi/commons/exceptions/InvalidAuthenticationException.java
@@ -1,0 +1,7 @@
+package lab.en2b.quizapi.commons.exceptions;
+
+public class InvalidAuthenticationException extends RuntimeException{
+    public InvalidAuthenticationException(String message) {
+        super(message);
+    }
+}

--- a/api/src/main/java/lab/en2b/quizapi/commons/user/UserService.java
+++ b/api/src/main/java/lab/en2b/quizapi/commons/user/UserService.java
@@ -2,6 +2,7 @@ package lab.en2b.quizapi.commons.user;
 
 import lab.en2b.quizapi.auth.config.UserDetailsImpl;
 import lab.en2b.quizapi.auth.dtos.RegisterDto;
+import lab.en2b.quizapi.commons.exceptions.InvalidAuthenticationException;
 import lab.en2b.quizapi.commons.user.role.RoleRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,7 +27,7 @@ public class UserService implements UserDetailsService {
     private long REFRESH_TOKEN_DURATION_MS;
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        return UserDetailsImpl.build(userRepository.findByEmail(email).orElseThrow());
+        return UserDetailsImpl.build(userRepository.findByEmail(email).orElseThrow(() -> new InvalidAuthenticationException("Invalid email or password provided!")));
     }
     public void createUser(RegisterDto registerRequest, Set<String> roleNames){
         if (userRepository.existsByEmail(registerRequest.getEmail()) || userRepository.existsByUsername(registerRequest.getUsername())) {


### PR DESCRIPTION
Invalid credentials now returns a 401 error that actually describes what went wrong instead of returning a 403 with a generic message.