### PR TITLE
Solved the link of the API docu in the lateral menu

### DIFF
--- a/webapp/src/components/LateralMenu.jsx
+++ b/webapp/src/components/LateralMenu.jsx
@@ -25,7 +25,7 @@ const LateralMenu = ({ isOpen, onClose, changeLanguage, isDashboard }) => {
     };
 
     const handleApiClick = () => {
-        window.open(`http://${process.env.REACT_APP_API_ENDPOINT}/swagger/swagger-ui/index.html#/auth-controller/registerUser`, "_blank", "noopener");
+        window.open(`${process.env.REACT_APP_API_ENDPOINT}/swagger/swagger-ui/index.html#/auth-controller/registerUser`, "_blank", "noopener");
     };    
 
     const handleLogout = async () => {


### PR DESCRIPTION
Fixed the typo in the API documentation url in the lateral menu. 