### PR TITLE
fix: add proxy deployment on release

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -73,6 +73,7 @@
     kiwiq:
       image: ghcr.io/arquisoft/wiq_en2b/kiwiq:latest
       container_name: kiwiq
+      profiles: ["dev", "prod"]
       networks:
         mynetwork:
       links:


### PR DESCRIPTION
This PR should fix an error I had not realized it could happen: the reverse proxy not deploying on release (and thus crashing the entire application.