### PR TITLE
Fix: missing 'SELECT' in API

### DIFF
--- a/api/src/main/java/lab/en2b/quizapi/game/GameRepository.java
+++ b/api/src/main/java/lab/en2b/quizapi/game/GameRepository.java
@@ -14,6 +14,7 @@ public interface GameRepository extends JpaRepository<Game,Long> {
     @Query(value = "SELECT * FROM Games g WHERE user_id = ?1 AND g.is_game_over = false LIMIT 1", nativeQuery = true)
     Optional<Game> findActiveGameForUser(Long userId);
 
-    @Query(value = "COUNT(*) FROM Games g WHERE user_id = ?1 AND g.is_game_over = true", nativeQuery = true)
+    @Query(value = "SELECT COUNT(*) FROM Games g WHERE user_id = ?1 AND g" +
+            ".is_game_over = true", nativeQuery = true)
     Long countFinishedGamesForUser(Long userId);
 }


### PR DESCRIPTION
I have found a missing SELECT in a query. This PR should fix it.