### PR TITLE
Sending error when confirmPassword is blank

### DIFF
--- a/webapp/public/locales/en/translation.json
+++ b/webapp/public/locales/en/translation.json
@@ -53,7 +53,9 @@
         "authorized": {
             "type": "Authorization Error: ",
             "message": "Invalid email or password, check for them to be correct"
-        }
+        },
+        "empty_password": "The confirm password label can not be empty",
+        "password_mismatch": "The password and confirm password labels must match"
     },
     "rules": {
         "description1": "Welcome to the exciting world of KiWiQ! In this challenging game, your goal is to embark on a journey full of knowledge and fun.",

--- a/webapp/public/locales/es/translation.json
+++ b/webapp/public/locales/es/translation.json
@@ -53,7 +53,9 @@
         "authorized": {
             "type": "Error de Autorización: ",
             "message": "Correo electrónico o contraseña no válidos, verifique que sean correctos"
-        }
+        },
+        "empty_password": "La confirmación de contraseña no puede estar vacía",
+        "password_mismatch": "Las contraseñas no coinciden"
     },
     "rules": {
         "description1": "¡Bienvenidos al emocionante mundo de KiWiQ! En este desafiante juego, tu objetivo es embarcarte en un viaje lleno de conocimiento y diversión.",

--- a/webapp/src/pages/Signup.jsx
+++ b/webapp/src/pages/Signup.jsx
@@ -19,6 +19,7 @@ export default function Signup() {
     const [showPassword, setShowPassword] = useState(false);
     const [showConfirmPassword, setShowConfirmPassword] = useState(false);
     const [errorMessage, setErrorMessage] = useState(null);
+    const [isSubmitting, setIsSubmitting] = useState(false); 
 
     const navigate = useNavigate();
     const { t, i18n } = useTranslation();
@@ -32,7 +33,13 @@ export default function Signup() {
             navigate("/dashboard");
         }
     }
+
     const sendRegistration = async () => {
+        setIsSubmitting(true); 
+        if (confirmPassword.trim() === "") {
+            setErrorMessage({ type: t("error.conflict.type"), message: t("error.empty_password") });
+            return;
+        }
         const registerData = {
             "email": email,
             "username": username,
@@ -169,7 +176,7 @@ export default function Signup() {
                                 </InputRightElement>
                             </InputGroup>
                             {confirmPassword && password && confirmPassword !== password && (
-                                <FormHelperText color="red">Las contraseñas no coinciden</FormHelperText>
+                                <FormHelperText color="red">{t("error.password_mismatch")}</FormHelperText>
                             )}
                         </FormControl>
                         <Flex>


### PR DESCRIPTION
Now we do not permit registering with empty confirmPassword layer.